### PR TITLE
リンクが切れているため互換IFの公開ドキュメントへリンクするよう変更。

### DIFF
--- a/lib/v2apiDevTool/views/top.erb
+++ b/lib/v2apiDevTool/views/top.erb
@@ -6,7 +6,7 @@
 <div id="contents_top">
   <!-- 社内用の仮ページなのでHTMLが適当ですひどいですすいません -->
   <p>
-    駅すぱあとイントラネットVer3に搭載予定の、V2APIテストサイトです。<br />
+    駅すぱあとイントラネット互換インターフェースのテストサイトです。<br />
     Ver2のCGIインターフェースにつきましても、基本的に現行の支援サイトと同等に利用することができます。<br />
     上部のメニューからCGIを選択してご利用ください。
   </p>
@@ -85,5 +85,5 @@
     ※IE7では履歴機能は使用できません。<br />
     ※IE6は非対応です。
   </p>
-  <p><a href="http://192.168.50.92:8080/job/v2apiManual/lastSuccessfulBuild/artifact/document/index.html">現在作成中のV3用マニュアル(Jenkinsによる自動ビルド。随時更新)</a></p>
+  <p><a href="http://docs.ekispert.com/compatible/index.html">イントラ互換IFドキュメント(本番公開)</a></p>
 </div>


### PR DESCRIPTION
ページ内に他にも開発時の内容が書かれていますが、
開発ツールの利用頻度が高くないことから後回しにします。